### PR TITLE
feat: TypeScript types

### DIFF
--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,0 +1,60 @@
+import type { PurchaseOrderLine, Vendor, Item } from './api';
+
+// ── Draft Order (local state during creation) ────────────
+
+export interface DraftOrderLine {
+  tempId: string;
+  item: Item;
+  quantity: number;
+  directUnitCost: number;
+  discountPercent: number;
+  lineType: 'Item' | 'Account' | 'Resource';
+  description: string;
+  unitOfMeasureCode: string;
+}
+
+export interface DraftOrder {
+  vendor: Vendor | null;
+  lines: DraftOrderLine[];
+  orderDate: Date;
+  requestedReceiptDate: Date | null;
+  notes: string;
+}
+
+// ── Filter State ─────────────────────────────────────────
+
+export type OrderFilterTab = 'All' | 'Draft' | 'Open' | 'Received';
+
+export interface FilterState {
+  tab: OrderFilterTab;
+  searchQuery: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+// ── User Profile ─────────────────────────────────────────
+
+export interface UserProfile {
+  username: string;
+  displayName: string;
+  isLoggedIn: boolean;
+  loginTimestamp: number;
+}
+
+// ── Scanned Document (placeholder for ADI) ───────────────
+
+export interface ScannedDocumentResult {
+  vendorName: string;
+  invoiceNumber: string;
+  invoiceDate: string;
+  lineItems: {
+    description: string;
+    quantity: number;
+    unitCost: number;
+    amount: number;
+  }[];
+  subtotal: number;
+  taxAmount: number;
+  totalAmount: number;
+  confidence: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './api';
+export * from './app';
+export * from './navigation';

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,54 @@
+import type { DraftOrder, ScannedDocumentResult } from './app';
+
+// ── Root Stack (Auth vs Main) ────────────────────────────
+
+export type RootStackParamList = {
+  Login: undefined;
+  Main: undefined;
+};
+
+// ── Bottom Tab Navigator ─────────────────────────────────
+
+export type BottomTabParamList = {
+  DashboardTab: undefined;
+  OrdersTab: undefined;
+  CreateTab: undefined;
+  InvoicesTab: undefined;
+  SettingsTab: undefined;
+};
+
+// ── Dashboard Stack ──────────────────────────────────────
+
+export type DashboardStackParamList = {
+  DashboardHome: undefined;
+  OrderDetail: { orderId: string };
+  CreateOrder: { prefillData?: Partial<DraftOrder> } | undefined;
+};
+
+// ── Orders Stack ─────────────────────────────────────────
+
+export type OrdersStackParamList = {
+  OrderList: undefined;
+  OrderDetail: { orderId: string };
+  EditOrder: { orderId: string };
+};
+
+// ── Create Stack ─────────────────────────────────────────
+
+export type CreateStackParamList = {
+  CreateOrder: { prefillData?: Partial<DraftOrder> } | undefined;
+  ScanDocument: undefined;
+};
+
+// ── Invoices Stack ───────────────────────────────────────
+
+export type InvoicesStackParamList = {
+  PostedInvoices: undefined;
+  InvoiceDetail: { invoiceId: string };
+};
+
+// ── Settings Stack ───────────────────────────────────────
+
+export type SettingsStackParamList = {
+  Settings: undefined;
+};


### PR DESCRIPTION
Closes #4

- Full BC API v2.0 type interfaces
- App types: DraftOrder, FilterState, UserProfile, ScannedDocumentResult
- Navigation route param types for all stacks